### PR TITLE
fixed link to project "typist"

### DIFF
--- a/content/projects.md
+++ b/content/projects.md
@@ -22,7 +22,7 @@ traditionelle `ipcalc` mit vielen Zustatzfeatures
 
 * [nept](https://github.com/noqqe/nept) Go Image Manipulation über die
 Kommandozeile
-* [typist](https://github.com/noqqe/stramap/) Go Tipptrainer mit `yaml`
+* [typist](https://github.com/noqqe/typist) Go Tipptrainer mit `yaml`
 Übungsdateien
 * [purple-yak](https://github.com/noqqe/purple-yak) Text Analyse mit Shannon Entropy und Zipf
 Distribution


### PR DESCRIPTION
fixed the link to the project "typist" which was pointing to the project "stramap"